### PR TITLE
chore: upgrade default cli version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Version of UiPath CLI to download'
     required: true
-    default: '23.10.8748.26221'
+    default: '23.10.8753.32995'
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Use version 23.10.8753.32995 from [UiPath Official feed](https://uipath.visualstudio.com/Public.Feeds/_artifacts/feed/UiPath-Official/NuGet/UiPath.CLI.Windows/versions/23.10.8753.32995)
