### PR TITLE
fix: update node version and npm packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: true
     default: '23.10.8753.32995'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/build-scripts.sh
+++ b/build-scripts.sh
@@ -3,6 +3,7 @@ npm install
 npm install @actions/core
 npm install @actions/github
 npm i -g @vercel/ncc
+npm audit fix
 ncc build index.js -o dist --source-map --license licenses.txt
 npm ci
 npm run prepare


### PR DESCRIPTION
- Upgrade action to run with node 20 due to end of life for node 16. See [GitHub blog post](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- Add npm audit fix to build scripts to improve maintenance of packages used