### PR TITLE
feat: use version 23.10.8894.39673 cli version for default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Version of UiPath CLI to download'
     required: true
-    default: '23.10.8753.32995'
+    default: '23.10.8894.39673'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update the default version as 23.10.8894.39673 which is the latest available version of the UiPath CLI