### PR TITLE
feat: use UiPath.CLI v24.10 as default version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Version of UiPath CLI to download'
     required: true
-    default: '23.10.8894.39673'
+    default: '24.10.9050.17872'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update the default version of UiPath.CLI to version 24.10.9050.17872.

[Release notes](https://docs.uipath.com/automation-ops/automation-cloud/latest/user-guide/release-notes-uipath-cli#v24100)