### PR TITLE
fix: set version 25.4.9301.33152 as default for platform version 25.4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28618,7 +28618,7 @@ async function getVersion(tool) {
   if (version == '') {
     switch(platformVersion) {
       case '25.4':
-        version = '25.4.9239.19674';
+        version = '25.4.9301.33152';
         break;
       case '24.12':
         version = '24.12.9166.24491';

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function getVersion(tool) {
   if (version == '') {
     switch(platformVersion) {
       case '25.4':
-        version = '25.4.9239.19674';
+        version = '25.4.9301.33152';
         break;
       case '24.12':
         version = '24.12.9166.24491';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1749,10 +1749,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6816,9 +6817,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
Set UiPath.CLI version 25.4.9301.33152 as the default version when providing 25.4 for platform, to include latest bug fixes related to working with source files