### PR TITLE
chore: update 25.4 version of cli

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28618,7 +28618,7 @@ async function getVersion(tool) {
   if (version == '') {
     switch(platformVersion) {
       case '25.4':
-        version = '25.4.9301.33152';
+        version = '25.4.9337.28376';
         break;
       case '24.12':
         version = '24.12.9166.24491';

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function getVersion(tool) {
   if (version == '') {
     switch(platformVersion) {
       case '25.4':
-        version = '25.4.9301.33152';
+        version = '25.4.9337.28376';
         break;
       case '24.12':
         version = '24.12.9166.24491';


### PR DESCRIPTION
New version of 25.4 CLI released in July - [25.4.9337.28376](https://uipath.visualstudio.com/Public.Feeds/_artifacts/feed/UiPath-Official/NuGet/UiPath.CLI.Windows/overview/25.4.9337.28376)